### PR TITLE
Add google as a keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "thujohn/analytics",
     "description": "Google Analytics for Laravel 4",
-	"keywords": ["analytics", "laravel", "laravel4"],
+	"keywords": ["google", "analytics", "laravel", "laravel4"],
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
You are not showing up here when searching for google http://registry.autopergamene.eu/
As a result I had started creating my own package. Right now my package is only a wrapper to get a google ID from config, but was planning on building it out with features like yours.
I'm going to add a deprecation notice to my repo linking to yours.
