### PR TITLE
Use the official Google API Client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.x",
-        "google/apiclient" : "~1.0.0"
+        "google/apiclient" : "~1.0.0-beta"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.x",
-        "bitgandtter/google-api": "dev-master"
+        "google/apiclient" : "~1.0.0"
     },
     "autoload": {
         "psr-0": {

--- a/src/Thujohn/Analytics/Analytics.php
+++ b/src/Thujohn/Analytics/Analytics.php
@@ -25,7 +25,7 @@ class Analytics {
 	}
 
 	public function setService(\Google_Client $client) {
-		$this->service = new \Google_AnalyticsService($client);
+		$this->service = new \Google_Service_Analytics($client);
 
 		return $this;
 	}
@@ -56,15 +56,9 @@ class Analytics {
 
 	public function getAllSitesIds() {
 		if (empty($this->site_ids)) {
-			if ($this->service->management_webproperties->useObjects()) {
-				foreach($this->service->management_profiles->listManagementProfiles("~all", "~all")->getItems() as $site){
-					$this->site_ids[$site->websiteUrl] = 'ga:' . $site->id;
-				}
-			}else{
-				$sites = $this->service->management_profiles->listManagementProfiles("~all", "~all");
-				foreach($sites['items'] as $site) {
-					$this->site_ids[$site['websiteUrl']] = 'ga:' . $site['id'];
-				}
+			$sites = $this->service->management_profiles->listManagementProfiles("~all", "~all");
+			foreach($sites['items'] as $site) {
+				$this->site_ids[$site['websiteUrl']] = 'ga:' . $site['id'];
 			}
 		}
 

--- a/src/Thujohn/Analytics/AnalyticsServiceProvider.php
+++ b/src/Thujohn/Analytics/AnalyticsServiceProvider.php
@@ -45,7 +45,7 @@ class AnalyticsServiceProvider extends ServiceProvider {
 			$client->setAccessType('offline');
 
 			$client->setAssertionCredentials(
-				new \Google_AssertionCredentials(
+				new \Google_Auth_AssertionCredentials(
 					$app['config']->get('analytics::service_email'),
 					array('https://www.googleapis.com/auth/analytics.readonly'),
 					file_get_contents($app['config']->get('analytics::certificate_path'))


### PR DESCRIPTION
Hi,

I've made some little changes to make use of the official Google PHP API Client instead of the outdated one (`bitgandtter/google-api`).

However, the install problem described in Issue #4 remains in my environment. I've to include the two requirements in my main composer.json:

```
"google/apiclient": "~1.0.0-beta",
"thujohn/analytics": "dev-master"
```

Best regards

Marcus
