### PR TITLE
If you have multiple views on the same url they will be overwritten and ...

### DIFF
--- a/src/Thujohn/Analytics/Analytics.php
+++ b/src/Thujohn/Analytics/Analytics.php
@@ -58,7 +58,7 @@ class Analytics {
 		if (empty($this->site_ids)) {
 			$sites = $this->service->management_profiles->listManagementProfiles("~all", "~all");
 			foreach($sites['items'] as $site) {
-				$this->site_ids[$site['websiteUrl']] = 'ga:' . $site['id'];
+				$this->site_ids[] = array('id' => 'ga:' . $site['id'], 'url' => $site['websiteUrl']);
 			}
 		}
 


### PR DESCRIPTION
...only the last one will be returned by getAllSitesIds().

That's why restructuring the returned array to either have the id as a key or nesting id and url one layer deeper makes sense.
