### PR TITLE
Improve the service provider

### DIFF
--- a/src/Thujohn/Analytics/AnalyticsServiceProvider.php
+++ b/src/Thujohn/Analytics/AnalyticsServiceProvider.php
@@ -28,8 +28,7 @@ class AnalyticsServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app['analytics'] = $this->app->share(function($app)
-		{
+		$this->app->bind('Thujohn\Analytics\Analytics', function ($app) {
 			if(!\File::exists($app['config']->get('analytics::certificate_path')))
 			{
 				throw new \Exception("Can't find the .p12 certificate in: " . $app['config']->get('analytics::certificate_path'));
@@ -54,6 +53,8 @@ class AnalyticsServiceProvider extends ServiceProvider {
 
 			return new Analytics($client);
 		});
+
+		$this->app->singleton('analytics', 'Thujohn\Analytics\Analytics');
 	}
 
 	/**


### PR DESCRIPTION
This makes the package much more flexible and allows dependency injection. eg:

``` php
protected $analytics;

public function __construct(\Thujohn\Analytics\Analytics $analytics)
{
    $this->analytics = $analytics;
}
```

The facade still behaves like before.
