### PR TITLE
Don't rely on the File alias

### DIFF
--- a/src/Thujohn/Analytics/AnalyticsServiceProvider.php
+++ b/src/Thujohn/Analytics/AnalyticsServiceProvider.php
@@ -29,7 +29,7 @@ class AnalyticsServiceProvider extends ServiceProvider {
 	public function register()
 	{
 		$this->app->bind('Thujohn\Analytics\Analytics', function ($app) {
-			if(!\File::exists($app['config']->get('analytics::certificate_path')))
+			if(!$app['files']->exists($app['config']->get('analytics::certificate_path')))
 			{
 				throw new \Exception("Can't find the .p12 certificate in: " . $app['config']->get('analytics::certificate_path'));
 			}


### PR DESCRIPTION
You shouldn't rely on an alias because, like us, a project may have removed them from `app.aliases`.
